### PR TITLE
Prevent Line Break

### DIFF
--- a/src/fancyTable.js
+++ b/src/fancyTable.js
@@ -196,7 +196,7 @@
 						html:content,
 						"data-n": nAElm,
 						class:""
-					}).css({"cursor":"pointer","color":"inherit","text-decoration":"none"}).bind("click",function(){
+					}).css({"cursor":"pointer","color":"inherit","text-decoration":"none","white-space":"nowrap"}).bind("click",function(){
 						if(elm.fancyTable.sortColumn == $(this).data("n")){
 							elm.fancyTable.sortOrder=-elm.fancyTable.sortOrder;
 						} else {


### PR DESCRIPTION
This small change prevents the triangle from jumping to another line in tables with many and long contents.

Before:
<img width="383" alt="Bildschirmfoto 2022-05-27 um 15 28 19" src="https://user-images.githubusercontent.com/2178466/170709509-0d35a028-939f-47f7-8e67-e45795ceafe9.png">

After:
<img width="387" alt="Bildschirmfoto 2022-05-27 um 15 28 24" src="https://user-images.githubusercontent.com/2178466/170709513-6f6e7fa9-e5fe-4c0f-ba95-5fa36e6347e2.png">
