### PR TITLE
Update numeric sortas to include currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Or manually by including the script *after* the jQuery library
 
 ## Data attributes
 
-**data-sortas="numeric"** - Used in the table header element <th> to define that values in the column should be sorted in numerical order (..., 8, 9, 10, 10.1, 12, ...)
+**data-sortas="numeric"** - Used in the table header element <th> to define that values in the column should be sorted in numerical order (..., 8, 9, 10, 10.1, 12, ...). Numbers starting with '-' or enclosed in parenthesis will be treated as negative.
 
 	<th data-sortas="numeric">
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.fancytable",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "A jQuery plugin for making html tables searchable and sortable with pagination.",
   "main": "dist/fancyTable.min.js",
   "directories": {

--- a/src/fancyTable.js
+++ b/src/fancyTable.js
@@ -29,9 +29,12 @@
 					return(fancyTableObject.rowSortOrder[$(rowA).data("rowid")] > fancyTableObject.rowSortOrder[$(rowB).data("rowid")]);
 				}
 				if(fancyTableObject.sortAs[fancyTableObject.sortColumn] == 'numeric'){
-					return(
-						(fancyTableObject.sortOrder>0) ? (parseFloat(a)||0)-(parseFloat(b)||0) : (parseFloat(b)||0)-(parseFloat(a)||0) // NaN values will be sorted as 0
-					);
+					[a, b] = [a, b].map(x => {
+						x = x.replace('$', '');
+						if (x.match(/[()]/g)) { x = -x.replaceAll(/[()]/g, ''); }
+						return parseFloat(x) || 0; // NaN values will be sorted as 0
+					});
+					return (fancyTableObject.sortOrder > 0) ? (a - b) : (b - a);
 				} else {
 					if(settings.localeCompare){
 						return((a.localeCompare(b)<0)?-fancyTableObject.sortOrder:(a.localeCompare(b)>0)?fancyTableObject.sortOrder:0); 


### PR DESCRIPTION
I needed to sort by currency, so I updated the sortas numeric type to handle currency - currently only currency that uses the dollar sign, ie USD, but it can easily be updated to include international currency symbols by replacing the `'$'` string on line 33 in the string.replace() with a regex (e.g. `/[$£€]/`). I also added handling negative numbers that are identified by enclosing the number in parenthesis.